### PR TITLE
Helper.php file with get_home_url() fix

### DIFF
--- a/payfort_fort/lib/payfortFort/classes/Helper.php
+++ b/payfort_fort/lib/payfortFort/classes/Helper.php
@@ -46,12 +46,12 @@ class Payfort_Fort_Helper extends Payfort_Fort_Super
 
     public function getReturnUrl($path)
     {
-        return get_site_url().'?wc-api=wc_gateway_payfort_fort_'.$path;
+        return get_home_url().'?wc-api=wc_gateway_payfort_fort_'.$path;
     }
 
     public function getUrl($path)
     {
-        $url = get_site_url().$path;
+        $url = get_home_url().$path;
         return $url;
     }
 


### PR DESCRIPTION
issue: WPML site on change language redirects on default language when return from payfort.

solution: Helper.php file with get_home_url() fix to solve redirection issues in WPML sites.