### PR TITLE
Force amount to be serialized as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ On the Checkout Options Click on Payfort .
 
 ## Changelog
 
+`v1.2.1`
+- Fix a bug where some specific amounts would cause a signature mismatch error.
+
 `v1.2.0`
 - Rearrange payment methods configuration in admin panel.
 - Added option for order placement.

--- a/payfort_fort/lib/payfortFort/classes/Helper.php
+++ b/payfort_fort/lib/payfortFort/classes/Helper.php
@@ -56,7 +56,7 @@ class Payfort_Fort_Helper extends Payfort_Fort_Super
     }
 
     /**
-     * Convert Amount with dicemal points
+     * Convert Amount with decimal points
      * @param decimal $amount
      * @param decimal $currency_value
      * @param string  $currency_code
@@ -75,7 +75,7 @@ class Payfort_Fort_Helper extends Payfort_Fort_Super
             $new_amount = round($amount, $decimal_points);
         }
         $new_amount = $new_amount * (pow(10, $decimal_points));
-        return $new_amount;
+        return "$new_amount";
     }
 
     /**

--- a/payfort_fort/woocommerce-fort.php
+++ b/payfort_fort/woocommerce-fort.php
@@ -3,7 +3,7 @@
 /* Plugin Name: Payfort (FORT)
  * Plugin URI:  https://github.com/payfort/woocommerce-payfort
  * Description: Payfort makes it really easy to start accepting online payments (credit &amp; debit cards) in the Middle East. Sign up is instant, at https://www.payfort.com/
- * Version:     1.2.0
+ * Version:     1.2.1
  * Author:      Payfort
  * Author URI:  https://www.payfort.com/
  */
@@ -18,7 +18,7 @@ if (in_array('woocommerce/woocommerce.php', $active_plugins)) {
     if (defined('PAYFORT_FORT_VERSION'))
         return;
 
-    define('PAYFORT_FORT_VERSION', '1.2.0');
+    define('PAYFORT_FORT_VERSION', '1.2.1');
 
 
     if (!defined('PAYFORT_FORT_DIR')) {


### PR DESCRIPTION
Fix issue where some values would be different between the JSON encoding and the string calculation leading to signature mismatch errors.

Pending:

- [x] Code Review Approval
- [x] QA Approval