### PR TITLE
http method is removed from validation schemes

### DIFF
--- a/includes/class-aps-ajax.php
+++ b/includes/class-aps-ajax.php
@@ -225,7 +225,7 @@ class APS_Ajax {
 				throw new \Exception( 'Apple pay url is invalid' );
 			}
 			$parse_apple = wp_parse_url( $apple_url );
-			if ( ! isset( $parse_apple['scheme'] ) || ! in_array( $parse_apple['scheme'], array( 'http', 'https' ), true ) ) {
+			if ( ! isset( $parse_apple['scheme'] ) || ! in_array( $parse_apple['scheme'], array( 'https' ), true ) ) {
 				throw new \Exception( 'Apple pay url is invalid' );
 			}
 			echo wp_kses_data($this->aps_helper->init_apple_pay_api( $apple_url ) );


### PR DESCRIPTION
'http' scheme is removed from the validate apple url function to enforce only https connections